### PR TITLE
Fix QT emit macro interfering with tbb

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -8,6 +8,8 @@ set(CMAKE_AUTOMOC TRUE)
 
 add_executable(${CmdName})
 
+target_compile_definitions(${CmdName} PRIVATE QT_NO_KEYWORDS)
+
 target_sources(${CmdName}
     PRIVATE
         CamPlayback.cc


### PR DESCRIPTION
Including some of the QT headers define an "emit" macro that causes clashes in some of the newer tbb headers which have function definitions called "emit", resulting in a build failure. Setting QT_NO_KEYWORDS makes QT not define those macros.